### PR TITLE
fixed deploy action typo

### DIFF
--- a/.github/workflows/update_changelog.yaml
+++ b/.github/workflows/update_changelog.yaml
@@ -14,7 +14,7 @@ name: Deploy
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   deploy:


### PR DESCRIPTION
There was a typo in [Deploy action](https://github.com/RohitKochhar/talbot/blob/main/.github/workflows/update_changelog.yaml) that prevented tags from being correctly identified