### PR TITLE
chore: add new action to check for commit message convention

### DIFF
--- a/.github/workflows/check_for_conventional_commit.yaml
+++ b/.github/workflows/check_for_conventional_commit.yaml
@@ -1,0 +1,14 @@
+name: Commit Convention Check
+
+on:
+  pull_request:
+    branches: ["**"]
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-for-cc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-for-cc
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v1.0.0


### PR DESCRIPTION
chore: add new action to check for commit message convention

Introduces a new GitHub action that checks that commit messages across all branches meets the commit standard specified [here](https://www.conventionalcommits.org/en/v1.0.0/)

Addresses Issue #19 